### PR TITLE
Add CRUD for login items in vault

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,6 +542,7 @@ dependencies = [
  "clap",
  "dirs",
  "jiff",
+ "serde",
  "serde_json",
  "tempfile",
 ]
@@ -1150,9 +1151,9 @@ checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
-version = "1.0.224"
+version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aaeb1e94f53b16384af593c71e20b095e958dab1d26939c1b70645c5cfbcc0b"
+checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1160,18 +1161,18 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.224"
+version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f39390fa6346e24defbcdd3d9544ba8a19985d0af74df8501fbfe9a64341ab"
+checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.224"
+version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ff78ab5e8561c9a675bfc1785cb07ae721f0ee53329a595cefd8c04c2ac4e0"
+checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,6 +551,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "uuid",
 ]
 
 [[package]]
@@ -722,6 +729,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
 dependencies = [
  "jiff-tzdb",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1079,6 +1096,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1367,6 +1390,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+dependencies = [
+ "getrandom 0.3.3",
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,6 +1439,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ dirs = "6.0.0"
 jiff = { version = "0.2.15", features = ["serde"] }
 serde = { version = "1.0.225", features = ["derive"] }
 serde_json = "1.0.145"
+uuid = {version = "1.18.1", features = ["v4", "serde"]}
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2024"
 age = "0.11.1"
 clap = { version = "4.5.47", features = ["derive"] }
 dirs = "6.0.0"
-jiff = "0.2.15"
+jiff = { version = "0.2.15", features = ["serde"] }
+serde = { version = "1.0.225", features = ["derive"] }
 serde_json = "1.0.145"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ mod tests {
         }
         "#;
 
-        let vault: Vault = get_vault(&data).unwrap();
+        let vault: Vault = get_vault(data).unwrap();
 
         assert_eq!(vault.item_list.len(), 2);
         assert_eq!(vault.item_list[0].username, "Gabe1");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,31 +1,60 @@
 pub mod models;
 
-use std::error::Error;
-
 pub use models::{LoginItem, Vault};
+use uuid::Uuid;
 
-pub fn get_vault(vault: &str) -> Result<Vault, Box<dyn Error>> {
-    let vault: Vault = serde_json::from_str(vault)?;
-    Ok(vault)
+impl Vault {
+    pub fn add_item(username: String, password: String, vault: &mut Vault) {
+        let login_item: LoginItem = LoginItem {
+            id: (Uuid::new_v4()),
+            username: (username),
+            password: (password),
+            created_at: (jiff::Timestamp::now()),
+            last_modified: (jiff::Timestamp::now()),
+        };
+
+        vault.item_list.push(login_item.clone());
+    }
+
+    pub fn update_item(username: Option<String>, password: Option<String>, item: &mut LoginItem) {
+        if !(username.is_none() && password.is_none()) {
+            if let Some(usn) = username {
+                item.username = usn;
+            }
+            if let Some(pwd) = password {
+                item.password = pwd;
+            }
+
+            item.last_modified = jiff::Timestamp::now()
+        }
+    }
+
+    pub fn delete_item_by_username(username: String, vault: &mut Vault) {
+        vault.item_list.retain(|x| x.username != username);
+    }
 }
 
 #[cfg(test)]
 mod tests {
 
+    use std::{thread::sleep, time::Duration};
+
     use super::*;
 
     #[test]
-    fn test_get_vault() {
+    fn test_from_str() {
         let data = r#"
           {
             "item_list": [
                 {
+                    "id": "550e8400-e29b-41d4-a716-446655440000",
                     "username": "Gabe1",
                     "password": "password1",
                     "created_at": 1718825365,
                     "last_modified": 1718825366
                 },
                 {
+                    "id": "550e8400-e29b-41d4-a716-446655440000",
                     "username": "Gabe2",
                     "password": "password2",
                     "created_at": 1718825367,
@@ -35,12 +64,134 @@ mod tests {
         }
         "#;
 
-        let vault: Vault = get_vault(data).unwrap();
+        let vault: Vault = serde_json::from_str(data).unwrap();
 
         assert_eq!(vault.item_list.len(), 2);
         assert_eq!(vault.item_list[0].username, "Gabe1");
         assert_eq!(vault.item_list[0].password, "password1");
         assert_eq!(vault.item_list[1].username, "Gabe2");
         assert_eq!(vault.item_list[1].password, "password2");
+    }
+
+    #[test]
+    fn test_add_item() {
+        let mut vault: Vault = Vault {
+            item_list: Vec::new(),
+        };
+        assert_eq!(vault.item_list.len(), 0);
+
+        Vault::add_item("Gabe".to_string(), "password".to_string(), &mut vault);
+        assert_eq!(vault.item_list.len(), 1);
+        assert_eq!(vault.item_list[0].username, "Gabe");
+        assert_eq!(vault.item_list[0].password, "password");
+    }
+
+    #[test]
+    fn test_update_item_username_and_password() {
+        let mut vault: Vault = Vault {
+            item_list: vec![LoginItem {
+                id: Uuid::new_v4(),
+                username: "Gabe".to_string(),
+                password: "password".to_string(),
+                last_modified: jiff::Timestamp::now(),
+                created_at: jiff::Timestamp::now(),
+            }],
+        };
+
+        assert_eq!(vault.item_list[0].username, "Gabe");
+        assert_eq!(vault.item_list[0].password, "password");
+        sleep(Duration::from_millis(100));
+
+        Vault::update_item(
+            Some("Leo".to_string()),
+            Some("pass word".to_string()),
+            &mut vault.item_list[0],
+        );
+
+        assert_eq!(vault.item_list[0].username, "Leo");
+        assert_eq!(vault.item_list[0].password, "pass word");
+        assert_ne!(
+            vault.item_list[0].created_at,
+            vault.item_list[0].last_modified
+        );
+    }
+
+    #[test]
+    fn test_update_item_username_only() {
+        let mut vault: Vault = Vault {
+            item_list: vec![LoginItem {
+                id: Uuid::new_v4(),
+                username: "Gabe".to_string(),
+                password: "password".to_string(),
+                last_modified: jiff::Timestamp::now(),
+                created_at: jiff::Timestamp::now(),
+            }],
+        };
+
+        assert_eq!(vault.item_list[0].username, "Gabe");
+        sleep(Duration::from_millis(100));
+        Vault::update_item(Some("Leo".to_string()), None, &mut vault.item_list[0]);
+        assert_eq!(vault.item_list[0].username, "Leo");
+        assert_ne!(
+            vault.item_list[0].created_at,
+            vault.item_list[0].last_modified
+        );
+    }
+
+    #[test]
+    fn test_update_item_password_only() {
+        let mut vault: Vault = Vault {
+            item_list: vec![LoginItem {
+                id: Uuid::new_v4(),
+                username: "Gabe".to_string(),
+                password: "password".to_string(),
+                last_modified: jiff::Timestamp::now(),
+                created_at: jiff::Timestamp::now(),
+            }],
+        };
+
+        assert_eq!(vault.item_list[0].password, "password");
+        sleep(Duration::from_millis(100));
+        Vault::update_item(None, Some("pass word".to_string()), &mut vault.item_list[0]);
+        assert_eq!(vault.item_list[0].password, "pass word");
+        assert_ne!(
+            vault.item_list[0].created_at,
+            vault.item_list[0].last_modified
+        );
+    }
+
+    #[test]
+    fn test_delete_by_username() {
+        let mut vault: Vault = Vault {
+            item_list: vec![
+                LoginItem {
+                    id: Uuid::new_v4(),
+                    username: "Gabe".to_string(),
+                    password: "password".to_string(),
+                    last_modified: jiff::Timestamp::now(),
+                    created_at: jiff::Timestamp::now(),
+                },
+                LoginItem {
+                    id: Uuid::new_v4(),
+                    username: "Leo".to_string(),
+                    password: "password".to_string(),
+                    last_modified: jiff::Timestamp::now(),
+                    created_at: jiff::Timestamp::now(),
+                },
+                LoginItem {
+                    id: Uuid::new_v4(),
+                    username: "Leo".to_string(),
+                    password: "password".to_string(),
+                    last_modified: jiff::Timestamp::now(),
+                    created_at: jiff::Timestamp::now(),
+                },
+            ],
+        };
+
+        assert_eq!(vault.item_list.len(), 3);
+        Vault::delete_item_by_username("Gabe".to_string(), &mut vault);
+        assert_eq!(vault.item_list.len(), 2);
+        Vault::delete_item_by_username("Leo".to_string(), &mut vault);
+        assert_eq!(vault.item_list.len(), 0);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,46 @@
+pub mod models;
+
+use std::error::Error;
+
+pub use models::{LoginItem, Vault};
+
+pub fn get_vault(vault: &str) -> Result<Vault, Box<dyn Error>> {
+    let vault: Vault = serde_json::from_str(vault)?;
+    Ok(vault)
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_get_vault() {
+        let data = r#"
+          {
+            "item_list": [
+                {
+                    "username": "Gabe1",
+                    "password": "password1",
+                    "created_at": 1718825365,
+                    "last_modified": 1718825366
+                },
+                {
+                    "username": "Gabe2",
+                    "password": "password2",
+                    "created_at": 1718825367,
+                    "last_modified": 1718825368
+                }
+            ]
+        }
+        "#;
+
+        let vault: Vault = get_vault(&data).unwrap();
+
+        assert_eq!(vault.item_list.len(), 2);
+        assert_eq!(vault.item_list[0].username, "Gabe1");
+        assert_eq!(vault.item_list[0].password, "password1");
+        assert_eq!(vault.item_list[1].username, "Gabe2");
+        assert_eq!(vault.item_list[1].password, "password2");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use std::error::Error;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::{fs, process};
 
 fn main() {
@@ -9,7 +9,7 @@ fn main() {
     println!("Hello, world!");
 }
 
-fn init(custom_dir: Option<&Path>) -> Result<(), Box<dyn Error>> {
+fn init(custom_dir: Option<&Path>) -> Result<PathBuf, Box<dyn Error>> {
     let vault_dir = match custom_dir {
         Some(dir) => dir.to_path_buf(),
         None => dirs::home_dir().ok_or("Could not determine home directory")?,
@@ -18,9 +18,10 @@ fn init(custom_dir: Option<&Path>) -> Result<(), Box<dyn Error>> {
     let exists = Path::exists(&vault_path);
     if !exists {
         fs::File::create(&vault_path)?;
+        fs::write(&vault_path, "{}")?;
     }
 
-    Ok(())
+    Ok(vault_dir)
 }
 
 #[cfg(test)]
@@ -43,6 +44,8 @@ mod tests {
         assert!(!vault_path.exists());
         assert!(init(Some(temp_path)).is_ok());
         assert!(vault_path.exists());
+        let content = fs::read_to_string(&vault_path).expect("Could not read vault file");
+        assert_eq!(content, "{}");
     }
 
     #[test]

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,0 +1,17 @@
+use jiff::Timestamp;
+//use serde::{Deserialize, Serialize};
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct LoginItem {
+    pub username: String, // can be an email
+    pub password: String,
+    #[serde(with = "jiff::fmt::serde::timestamp::second::required")]
+    pub created_at: Timestamp,
+    #[serde(with = "jiff::fmt::serde::timestamp::second::required")]
+    pub last_modified: Timestamp,
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct Vault {
+    pub item_list: Vec<LoginItem>,
+}

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,8 +1,10 @@
 use jiff::Timestamp;
+use uuid::Uuid;
 //use serde::{Deserialize, Serialize};
 
-#[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, serde::Deserialize, serde::Serialize, Clone)]
 pub struct LoginItem {
+    pub id: Uuid,
     pub username: String, // can be an email
     pub password: String,
     #[serde(with = "jiff::fmt::serde::timestamp::second::required")]


### PR DESCRIPTION
Add three functions to support CRUD operations for login items in the password vault:
- add_item
- update_item
- delete_item_by_username